### PR TITLE
feat(encrypt): add native post encryption with AES-256-GCM + Web Cryp…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,12 @@
     "allow": [
       "Read(//Users/gjx/Projects/vluv/source/**)",
       "Bash(wc:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(du:*)",
+      "Bash(find source:*)",
+      "Bash(bun add:*)",
+      "Bash(git commit:*)",
+      "Bash(git add:*)"
     ]
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@swup/head-plugin": "^2.3.1",
         "@swup/scripts-plugin": "^2.1.0",
         "date-fns": "^4.1.0",
-        "esbuild": "^0.27.3",
+        "esbuild": "^0.27.4",
         "hexo-pagination": "^4.0.0",
         "inferno": "^9.0.11",
         "inferno-create-element": "^9.0.11",

--- a/include/hexo/encrypt.js
+++ b/include/hexo/encrypt.js
@@ -1,0 +1,42 @@
+const crypto = require("node:crypto");
+
+const ITERATIONS = 100_000;
+
+module.exports = (hexo) => {
+  hexo.extend.filter.register(
+    "after_post_render",
+    (data) => {
+      const password = data.password;
+      if (!password && password !== 0) return data;
+
+      const passphrase = String(password);
+      const __ = hexo.theme.i18n.__(hexo.config.language);
+
+      const salt = crypto.randomBytes(16);
+      const iv = crypto.randomBytes(12);
+      const key = crypto.pbkdf2Sync(passphrase, salt, ITERATIONS, 32, "sha256");
+      const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+      const encrypted = Buffer.concat([cipher.update(data.content, "utf8"), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      const base64 = Buffer.concat([salt, iv, encrypted, tag]).toString("base64");
+
+      data.content = `
+<div class="encrypted-content" id="encrypted-article">
+  <div class="encrypted-data" style="display:none">${base64}</div>
+  <form class="encrypt-form" id="encrypt-form">
+    <p class="encrypt-message">${__("encrypt.message")}</p>
+    <div class="encrypt-input-wrap">
+      <input type="password" id="encrypt-pass" placeholder="${__("encrypt.placeholder")}" enterkeyhint="done" autocomplete="off" />
+    </div>
+  </form>
+</div>`;
+
+      data.excerpt = `<p>${__("encrypt.abstract")}</p>`;
+      data.more = "";
+      data.encrypt = true;
+
+      return data;
+    },
+    1000,
+  );
+};

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -43,3 +43,8 @@ search:
   no_result: "No results for"
   untitled: "(Untitled)"
   empty_preview: "(No preview)"
+encrypt:
+  message: "This article is encrypted, please enter the password to view"
+  placeholder: "Enter password..."
+  wrong_pass: "Wrong password, please try again"
+  abstract: "This article is encrypted"

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -43,3 +43,8 @@ search:
   no_result: "未找到搜索结果"
   untitled: "(无标题)"
   empty_preview: "(无内容预览)"
+encrypt:
+  message: "此文章已加密，请输入密码查看"
+  placeholder: "输入密码..."
+  wrong_pass: "密码错误，请重试"
+  abstract: "此文章已加密"

--- a/layout/common/head.jsx
+++ b/layout/common/head.jsx
@@ -154,6 +154,7 @@ module.exports = class extends Component {
         <link rel="preconnect" href="https://fontsapi.zeoseven.com" />
         <link rel="preload" as="style" href="https://fontsapi.zeoseven.com/442/main/result.css" onload="this.onload=null;this.rel='stylesheet'" />
         <link rel="preload" as="style" href="/css/shiki/shiki.css" onload="this.onload=null;this.rel='stylesheet'" />
+        {page.encrypt ? <link rel="stylesheet" href={url_for("/css/encrypt.css")} /> : null}
         <Plugins site={site} config={config} helper={helper} page={page} head={true} />
       </head>
     );

--- a/layout/common/scripts.jsx
+++ b/layout/common/scripts.jsx
@@ -14,6 +14,7 @@ module.exports = class extends Component {
         <script defer src="/js/theme-selector.js"></script>
         <script defer src="/js/host/medium-zoom/dist/medium-zoom.min.js"></script>
         <script defer src="/js/main.js"></script>
+        {page.encrypt ? <script src="/js/decrypt.js" type="module"></script> : null}
         <script async src="/js/instant-page.min.js" type="module"></script>
       </Fragment>
     );

--- a/layout/common/toc.jsx
+++ b/layout/common/toc.jsx
@@ -8,19 +8,19 @@ class FloatingToc extends Component {
       list_number: false,
     });
 
-    if (!tocContent) {
+    if (!tocContent && !page.encrypt) {
       return null;
     }
 
     return (
-      <div class="toc-container" id="icarus-toc-container">
+      <div class="toc-container" id="icarus-toc-container" style={page.encrypt ? "display:none" : null}>
         <button class="toc-button" type="button" popovertarget="toc-body" aria-label="Table of Contents">
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
         </button>
         <div id="toc-body" popover="auto" class="toc-body" onclick="if(event.target===this||event.target.closest('.toc-link'))this.hidePopover();">
-          <div dangerouslySetInnerHTML={{ __html: tocContent }} />
+          <div id="toc-insert" dangerouslySetInnerHTML={{ __html: tocContent || "" }} />
         </div>
       </div>
     );

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,5 +1,6 @@
 require("../include/hexo/filter")(hexo);
 require("../include/hexo/generator")(hexo);
+require("../include/hexo/encrypt")(hexo);
 require("../include/hexo/view").init(hexo);
 require("../include/hexo/helper")(hexo);
 require("../include/hexo/renderer")(hexo);

--- a/source/css/encrypt.css
+++ b/source/css/encrypt.css
@@ -1,0 +1,55 @@
+.encrypted-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  padding: 2rem 1rem;
+}
+
+.encrypt-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.encrypt-message {
+  color: var(--overlay0);
+  font-size: 0.95rem;
+  text-align: center;
+  margin: 0;
+}
+
+.encrypt-input-wrap {
+  width: 100%;
+}
+
+.encrypt-input-wrap input {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border: 1.5px solid var(--surface2);
+  border-radius: var(--radius);
+  background: var(--mantle);
+  color: var(--text);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.encrypt-input-wrap input:focus {
+  border-color: var(--lavender);
+}
+
+.encrypt-input-wrap input::placeholder {
+  color: var(--overlay0);
+}
+
+.encrypt-error {
+  color: var(--red);
+  font-size: 0.85rem;
+  margin: 0;
+}

--- a/source/js/decrypt.js
+++ b/source/js/decrypt.js
@@ -1,0 +1,126 @@
+function getCacheKey() {
+  return "gnix-encrypt:" + location.pathname;
+}
+
+function b64ToBytes(base64) {
+  const bin = atob(base64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+async function deriveKey(password, salt) {
+  const material = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
+  );
+}
+
+async function decryptPayload(password, base64) {
+  const data = b64ToBytes(base64);
+  const salt = data.slice(0, 16);
+  const iv = data.slice(16, 28);
+  const ciphertext = data.slice(28);
+  const key = await deriveKey(password, salt);
+  const plain = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  return new TextDecoder().decode(plain);
+}
+
+function buildToc() {
+  const tocContainer = document.getElementById("icarus-toc-container");
+  if (!tocContainer) return;
+  const headings = document.querySelectorAll(
+    ".content h1[id], .content h2[id], .content h3[id], .content h4[id], .content h5[id], .content h6[id]",
+  );
+  if (!headings.length) return;
+  const ol = document.createElement("ol");
+  ol.className = "toc";
+  for (const h of headings) {
+    const li = document.createElement("li");
+    li.className = "toc-item toc-level-" + h.tagName[1];
+    const a = document.createElement("a");
+    a.className = "toc-link";
+    a.href = "#" + h.id;
+    const span = document.createElement("span");
+    span.className = "toc-text";
+    span.textContent = h.textContent;
+    a.appendChild(span);
+    li.appendChild(a);
+    ol.appendChild(li);
+  }
+  const insert = tocContainer.querySelector("#toc-insert");
+  if (insert) {
+    insert.innerHTML = "";
+    insert.appendChild(ol);
+  }
+  tocContainer.style.display = "";
+}
+
+async function decrypt(container, password) {
+  const base64 = container.querySelector(".encrypted-data").textContent.trim();
+  const html = await decryptPayload(password, base64);
+  container.outerHTML = html;
+  localStorage.setItem(getCacheKey(), password);
+  buildToc();
+  if (typeof initPage === "function") initPage();
+}
+
+function showError(container) {
+  const form = container.querySelector("#encrypt-form");
+  let el = form.querySelector(".encrypt-error");
+  if (!el) {
+    el = document.createElement("p");
+    el.className = "encrypt-error";
+    form.appendChild(el);
+  }
+  el.textContent = document.documentElement.lang === "zh-CN" ? "密码错误，请重试" : "Wrong password, please try again";
+  const input = container.querySelector("#encrypt-pass");
+  if (input) {
+    input.value = "";
+    input.focus();
+  }
+}
+
+async function tryDecrypt(container, password) {
+  try {
+    await decrypt(container, password);
+  } catch {
+    showError(container);
+  }
+}
+
+function init() {
+  const container = document.getElementById("encrypted-article");
+  if (!container) return;
+  const cached = localStorage.getItem(getCacheKey());
+  if (cached) {
+    tryDecrypt(container, cached);
+    return;
+  }
+  const form = container.querySelector("#encrypt-form");
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const pw = container.querySelector("#encrypt-pass")?.value.trim();
+      if (pw) tryDecrypt(container, pw);
+    });
+  }
+  const input = container.querySelector("#encrypt-pass");
+  if (input) input.focus();
+}
+
+init();
+
+if (typeof swup !== "undefined") {
+  swup.hooks.on("page:view", init);
+}

--- a/source/js/mdit/mermaid.js
+++ b/source/js/mdit/mermaid.js
@@ -1,6 +1,9 @@
 (() => {
   const instances = new Map();
   let mermaidPromise = null;
+  let renderSeq = 0;
+  let lastTheme = document.documentElement.classList.contains("night");
+
   const loadMermaid = (jsUrl) => {
     if (mermaidPromise) return mermaidPromise;
     if (window.mermaid) {
@@ -21,11 +24,15 @@
     const mermaid = await mermaidPromise;
     if (!content || !mermaid) return;
 
-    // Initialize with current theme
+    const instance = instances.get(id);
+    if (!instance) return;
+    const version = (instance.renderVersion = ++renderSeq);
+
+    const isNight = document.documentElement.classList.contains("night");
     mermaid.initialize({
       startOnLoad: false,
-      theme: document.documentElement.classList.contains("night") ? "dark" : "default",
-      darkMode: document.documentElement.classList.contains("night"),
+      theme: isNight ? "dark" : "default",
+      darkMode: isNight,
       themeVariables,
       securityLevel: "strict",
       fontSize: 16,
@@ -33,9 +40,11 @@
 
     try {
       content.innerHTML = "";
-      const { svg } = await mermaid.render(`${id}-svg`, code);
+      const { svg } = await mermaid.render(`${id}-svg-${version}`, code);
+      if (instance.renderVersion !== version) return;
       content.insertAdjacentHTML("beforeend", svg);
     } catch (error) {
+      if (instance.renderVersion !== version) return;
       console.error("Mermaid rendering error:", error);
       content.innerHTML = `<p style="color: red;">Failed to render diagram: ${error.message}</p>`;
     }


### PR DESCRIPTION
…to API

Replace hexo-blog-encrypt plugin with built-in theme encryption. Server-side PBKDF2+AES-256-GCM via Node crypto, client-side decryption via Web Crypto API (zero dependencies, 4KB). Supports password caching, TOC generation after decrypt, and Swup SPA navigation.